### PR TITLE
fix(crypto): use proper integer types in sodium interop

### DIFF
--- a/Algorand.Unity.Package/ProjectSettings/ProjectSettings.asset
+++ b/Algorand.Unity.Package/ProjectSettings/ProjectSettings.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d947654d02cd60a55d83be02891bbc408f9d2a6184f4c19d91676f1cee862e6
-size 25483
+oid sha256:253b5839d70033e367a26fa93318e3ba3ba452022b3114853dd7f76b5ccd0ef2
+size 25518

--- a/Runtime/Algorand.Unity.Crypto/Interop/sodium/sodium.Ed25519.cs
+++ b/Runtime/Algorand.Unity.Crypto/Interop/sodium/sodium.Ed25519.cs
@@ -13,26 +13,33 @@ namespace Algorand.Unity.Crypto
 
 #if (UNITY_WEBGL && !UNITY_EDITOR)
         [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern void crypto_sign_ed25519_detached(
+        internal static extern void crypto_sign_ed25519_detached(
             void* signature,
             void* message,
-            UIntPtr messageLength,
+            int messageLength,
             IntPtr sk);
-#else
-        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern int crypto_sign_ed25519_detached(
-            void* signature,
-            out UIntPtr signatureLength_p,
-            void* message,
-            UIntPtr messageLength,
-            IntPtr sk);
-#endif
 
         [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int crypto_sign_ed25519_verify_detached(
             void* signature,
             void* message,
-            UIntPtr messageLength,
+            int messageLength,
             void* pk);
+#else
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crypto_sign_ed25519_detached(
+            void* signature,
+            out ulong signatureLength_p,
+            void* message,
+            ulong messageLength,
+            IntPtr sk);
+
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crypto_sign_ed25519_verify_detached(
+            void* signature,
+            void* message,
+            ulong messageLength,
+            void* pk);
+#endif
     }
 }

--- a/Runtime/Algorand.Unity.Crypto/Interop/sodium/sodium.Sha512.cs
+++ b/Runtime/Algorand.Unity.Crypto/Interop/sodium/sodium.Sha512.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 using Algorand.Unity.LowLevel;
 
@@ -11,7 +10,7 @@ namespace Algorand.Unity.Crypto
         internal static extern void crypto_hash_sha512_256(
             void* output, 
             void* @in, 
-            UIntPtr inlen);
+            int inlen);
 #else
         [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int crypto_hash_sha512_init(
@@ -21,7 +20,7 @@ namespace Algorand.Unity.Crypto
         internal static extern int crypto_hash_sha512_update(
             void* state,
             void* @in,
-            UIntPtr inlen);
+            ulong inlen);
 
         [DllImport(Library, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int crypto_hash_sha512_final(

--- a/Runtime/Algorand.Unity.Crypto/SecureMemoryHandle.cs
+++ b/Runtime/Algorand.Unity.Crypto/SecureMemoryHandle.cs
@@ -24,17 +24,10 @@ namespace Algorand.Unity.Crypto
 
         public static SecureMemoryHandle Create(UIntPtr sizeBytes)
         {
-            var ptr = sodium.sodium_malloc(sizeBytes);
-            return new SecureMemoryHandle(ptr);
+            return sodium_malloc(sizeBytes);
         }
 
-        public bool IsCreated
-        {
-            get
-            {
-                return Ptr != IntPtr.Zero;
-            }
-        }
+        public bool IsCreated => Ptr != IntPtr.Zero;
 
         public JobHandle Dispose(JobHandle inputDeps)
         {
@@ -58,6 +51,16 @@ namespace Algorand.Unity.Crypto
             {
                 keyHandle.Dispose();
             }
+        }
+
+        public static implicit operator IntPtr(SecureMemoryHandle handle)
+        {
+            return handle.Ptr;
+        }
+
+        public static implicit operator SecureMemoryHandle(IntPtr ptr)
+        {
+            return new SecureMemoryHandle(ptr);
         }
     }
 }

--- a/Runtime/Algorand.Unity.Crypto/Sha512.cs
+++ b/Runtime/Algorand.Unity.Crypto/Sha512.cs
@@ -29,7 +29,7 @@ namespace Algorand.Unity.Crypto
         {
             unsafe
             {
-                return Hash256Truncated(bytes.GetUnsafePtr(), bytes.Length);
+                return Hash256Truncated((byte*)bytes.GetUnsafePtr(), bytes.Length);
             }
         }
 
@@ -37,20 +37,20 @@ namespace Algorand.Unity.Crypto
         {
             unsafe
             {
-                return Hash256Truncated(bytes.GetUnsafeReadOnlyPtr(), bytes.Length);
+                return Hash256Truncated((byte*)bytes.GetUnsafeReadOnlyPtr(), bytes.Length);
             }
         }
 
-        public unsafe static Sha512_256_Hash Hash256Truncated(void* ptr, int length)
+        public unsafe static Sha512_256_Hash Hash256Truncated(byte* ptr, int length)
         {
             var result = new Sha512_256_Hash();
 #if (UNITY_WEBGL && !UNITY_EDITOR)
-            crypto_hash_sha512_256(&result, ptr, (UIntPtr)length);
+            crypto_hash_sha512_256(&result, ptr, length);
 #else
             var hashState = default(crypto_hash_sha512_state);
             crypto_hash_sha512_init(&hashState);
             hashState.vector = FIPS_Sha512_256_IV;
-            crypto_hash_sha512_update(&hashState, ptr, (UIntPtr)length);
+            crypto_hash_sha512_update(&hashState, ptr, (ulong)length);
             var hash512 = new Sha512_Hash();
             crypto_hash_sha512_final(&hashState, &hash512);
             ByteArray.CopyTo(hash512, ref result);

--- a/Tests/Runtime/Algorand.Unity.Crypto.Tests/Algorand.Unity.Crypto.Tests.asmdef
+++ b/Tests/Runtime/Algorand.Unity.Crypto.Tests/Algorand.Unity.Crypto.Tests.asmdef
@@ -7,7 +7,9 @@
         "GUID:e0cd26848372d4e5c891c569017e11f1",
         "GUID:2665a8d13d1b3f18800f46e256720795",
         "GUID:d8b63aba1907145bea998dd612889d6b",
-        "GUID:9f8c967ec86c9324c9b2928ff73b4cf1"
+        "GUID:9f8c967ec86c9324c9b2928ff73b4cf1",
+        "GUID:2ee6601452ca245499e63674423f6541",
+        "GUID:70d524b45145c40acbd35603c8e43743"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/Runtime/Algorand.Unity.Crypto.Tests/Sha512Test.cs
+++ b/Tests/Runtime/Algorand.Unity.Crypto.Tests/Sha512Test.cs
@@ -1,12 +1,19 @@
+using System;
+using Algorand.Unity.Collections;
 using Algorand.Unity.Crypto;
 using Algorand.Unity.LowLevel;
 using NUnit.Framework;
+using Unity.Collections;
 
 public class Sha512Test
 {
-    private static readonly (Ed25519.Seed, string)[] ValidHashes = new (Ed25519.Seed, string)[]
+    private static readonly (string, string)[] ValidHashes = new (string, string)[]
     {
-        (default, "rxPASJkSJKXkxmREa2iKr0j7VFbbNilgGwDsFgx05VQ=")
+        ("hello", "e30d87cfa2a75db545eac4d61baf970366a8357c7f72fa95b52d0accb698f13a"),
+        ("world", "b8007fc640bef3e2f10ea7ad9681f6fdbd132887406960f365452ba0a15e65e2"),
+        ("something for nothing", "0a9bd59712f41292d3d161cbb4bed989f317559890a1ccf21098df2ab8be399c"),
+        ("", "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a"),
+        ("1234567890", "89845297b53545520e05ec446aa8c7dc6a9df1171d54d182aec7ca346e44df0d")
     };
 
     [Test]
@@ -22,8 +29,11 @@ public class Sha512Test
     {
         foreach (var (seed, expected) in ValidHashes)
         {
-            var hash = Sha512.Hash256Truncated(seed);
-            var actual = hash.ToBase64();
+            using var text = new NativeText(seed, Allocator.Temp);
+            var arr = text.AsArray();
+            var bytes = new NativeByteArray(arr);
+            var hash = Sha512.Hash256Truncated(bytes);
+            var actual = BitConverter.ToString(hash.ToArray()).Replace("-", "").ToLower();
             Assert.AreEqual(expected, actual);
         }
     }


### PR DESCRIPTION
this fixes incorrect sizes of integers on 64-bit vs 32-bit systems

fix #187